### PR TITLE
Collect stats on checkpoint age

### DIFF
--- a/triton/checkpoint_test.go
+++ b/triton/checkpoint_test.go
@@ -2,7 +2,6 @@ package triton
 
 import (
 	"database/sql"
-	"fmt"
 	"os"
 	"testing"
 


### PR DESCRIPTION
Give some simple command line insights into running triton clients

Output looks like:

    $ go run triton.go stats --client-name store
    store.courier_activity_prod.shardId-000000000000.age 6664263
    store.courier_activity_prod.shardId-000000000001.age 6664263
    store.courier_activity_prod.shardId-000000000002.age 6664263
    store.courier_activity_prod.shardId-000000000003.age 6664263

Where the value is number of seconds since a checkpoint was saved.