### PR TITLE
Convert mock client to send signal with channel

### DIFF
--- a/tritond/mock_test.go
+++ b/tritond/mock_test.go
@@ -15,6 +15,7 @@ func TestMockClientPut(t *testing.T) {
 		"example2": "world",
 	}
 	err := c.Put(context.Background(), "delivery", "delivery-uuid", data)
+	assert.True(t, <-c.WriteSignal)
 	assert.NoError(t, err)
 	assert.EqualValues(t, data, c.StreamData["delivery"][0])
 }


### PR DESCRIPTION
Channels should give a more reliable way to check for completion on a concurrent test